### PR TITLE
Only demux the videoStream

### DIFF
--- a/createBootAnimation.py
+++ b/createBootAnimation.py
@@ -87,7 +87,7 @@ if args.extract:
         os.makedirs("tmp")
 
     bar = progressbar.ProgressBar(max_value=videoStream.frames, redirect_stdout=True)
-    for packet in bar(container.demux()):
+    for packet in bar(container.demux(videoStream)):
         for frame in packet.decode():
             if type(frame) == av.video.frame.VideoFrame:
                 frame.to_image().save(("tmp/%%0%dd.png" % numDigits) % frame.index)


### PR DESCRIPTION
When demuxing more than one stream... the progressbar will go out of range and throw an exception, this commit fixes that.

✌🏼

Backtrace:

```
./createBootAnimation.py video.mp4

Info: 432x240 @ 29fps (149 frames)

Extrating frames from video...
 90% (135 of 149) |################################################################################         | Elapsed Time: 0:00:00 ETA:   0:00:00
Traceback (most recent call last):
  File "/home/cetinajero/Boot-Animation-Factory-master/./createBootAnimation.py", line 90, in <module>
    for packet in bar(container.demux()):
  File "/home/cetinajero/.local/lib/python3.10/site-packages/progressbar/bar.py", line 558, in __next__
    self.update(self.value + 1)
  File "/home/cetinajero/.local/lib/python3.10/site-packages/progressbar/bar.py", line 672, in update
    raise ValueError(
ValueError: Value 150 is out of range, should be between 0 and 149
```